### PR TITLE
Only variables should be passed by reference to the end() function in ClientObject.php line 57

### DIFF
--- a/src/ClientObject.php
+++ b/src/ClientObject.php
@@ -54,7 +54,8 @@ abstract class ClientObject
     {
         $path = $this->resourcePath;
         if(!isset($path)){
-            $path = strtolower(end(explode("\\",get_class($this))));
+            $explode = explode("\\",get_class($this));
+            $path = strtolower(end($explode));
         }
         if(isset($this->parentResourcePath)) {
             $path = $this->parentResourcePath . "/" . $path;


### PR DESCRIPTION
This array is passed by reference because it is modified by the function. This means you must pass it a real variable and not a function returning an array because only actual variables may be passed by reference.
